### PR TITLE
Add WPF → Avalonia migration scaffold

### DIFF
--- a/docs/avalonia-migration.md
+++ b/docs/avalonia-migration.md
@@ -1,0 +1,128 @@
+# Avalonia Migration Scaffold for Edda
+
+This document provides a structured path for migrating Edda from WPF to Avalonia without attempting a risky one-shot rewrite.
+
+## Goals
+
+- Preserve current editor behavior.
+- Move non-UI logic out of WPF-specific code.
+- Create a clear separation between application logic and presentation.
+- Introduce an Avalonia UI incrementally.
+- Keep the existing WPF application usable during the migration.
+
+## Current state
+
+The current repository is centered around:
+
+- `Windows/` for WPF views and code-behind
+- `Classes/` for editor logic, audio, helper utilities, converters, and settings
+- NAudio-based audio playback and editor interaction logic
+
+## Target architecture
+
+Suggested long-term structure:
+
+- `src/Edda.Core/`
+  - editor state
+  - domain models
+  - shared services
+  - file/map conversion logic
+- `src/Edda.App/`
+  - application services
+  - commands
+  - abstractions for dialogs, clipboard, file picking, and notifications
+- `src/Edda.Avalonia/`
+  - Avalonia views
+  - view models
+  - Avalonia-specific adapters
+- `src/Edda.Wpf/`
+  - optional landing place for legacy WPF UI during migration
+
+This repo does not need to be reorganized immediately. The scaffold exists to guide future changes.
+
+## Migration strategy
+
+### Phase 1: Inventory and isolate
+
+1. Identify WPF-specific code in `Windows/`.
+2. Identify reusable logic in `Classes/`.
+3. Introduce view models for the highest-value windows.
+4. Replace direct UI logic in code-behind with calls into view models or services.
+
+### Phase 2: Extract shared services
+
+Extract interfaces for:
+
+- file dialogs
+- message dialogs
+- settings access
+- clipboard
+- dispatcher / UI-thread invocation
+- audio output selection, if UI-triggered
+
+Keep concrete WPF implementations in the legacy UI layer.
+
+### Phase 3: Introduce Avalonia shell
+
+Create a minimal Avalonia application that can host:
+
+- application startup
+- a placeholder main window
+- one migrated settings or utility screen
+
+### Phase 4: Incremental screen migration
+
+Recommended order:
+
+1. `SettingsWindow`
+2. simple dialogs and utility windows
+3. editor-adjacent panels with mostly form controls
+4. `MainWindow`
+
+### Phase 5: Remove WPF dependencies from shared flow
+
+As screens move to Avalonia:
+
+- stop referencing WPF types from extracted logic
+- move remaining shared logic into framework-agnostic classes
+- keep platform-specific implementations behind interfaces
+
+## High-priority extraction candidates
+
+The following areas are likely good first targets:
+
+- settings editing flow
+- map metadata editing
+- validation and parsing helpers
+- non-visual editor commands
+- import / conversion workflows
+
+These are typically easier to migrate than the full editor canvas.
+
+## Avalonia-specific notes
+
+When porting WPF UI to Avalonia:
+
+- do not assume XAML is drop-in compatible
+- replace WPF-specific APIs intentionally
+- move logic out of code-behind first
+- avoid porting `Dispatcher` usage directly without an abstraction
+- treat drag-and-drop, clipboard, and dialogs as platform services
+
+## Validation guidance
+
+For migration PRs, prefer this order:
+
+1. unit-test shared extracted logic
+2. build the current WPF application
+3. build the new Avalonia project once introduced
+4. verify migrated workflows manually
+
+## Definition of done for each migrated screen
+
+A screen is considered migrated when:
+
+- its behavior is represented by framework-agnostic view models or services
+- Avalonia UI exists for the workflow
+- no new WPF-only logic is added to the shared path
+- validation notes are recorded in the PR summary

--- a/docs/avalonia-workplan.md
+++ b/docs/avalonia-workplan.md
@@ -1,0 +1,112 @@
+# Avalonia Migration Workplan
+
+This document tracks concrete steps toward introducing an Avalonia UI for Edda.
+
+## Stage 0 — Preparation
+
+Tasks:
+
+- Audit WPF-only dependencies
+- Identify logic in `Windows/` that should move to shared services
+- Document UI windows and their responsibilities
+
+Output:
+
+- migration inventory
+- prioritized screen list
+
+## Stage 1 — Core extraction
+
+Tasks:
+
+- Introduce view models for:
+  - Settings
+  - audio device selection
+  - map metadata
+
+- Move non-UI logic from code-behind into:
+
+```
+Classes/ViewModels/
+Classes/Services/
+```
+
+Goal:
+
+Allow both WPF and Avalonia UIs to consume the same logic.
+
+## Stage 2 — Avalonia project introduction
+
+Create:
+
+```
+src/Edda.Avalonia/
+```
+
+Minimal project responsibilities:
+
+- Application bootstrap
+- Main window shell
+- dependency wiring
+
+No editor logic should live here.
+
+## Stage 3 — First migrated screen
+
+Recommended first migration:
+
+- Settings window
+
+Why:
+
+- mostly forms
+- minimal rendering logic
+
+Steps:
+
+1. Extract view model
+2. Bind WPF UI to the new view model
+3. Create Avalonia view bound to the same view model
+
+## Stage 4 — Shared services stabilization
+
+Introduce abstractions for:
+
+- dialogs
+- file picking
+- UI dispatcher
+- clipboard
+
+Example interface:
+
+```
+IFileDialogService
+IMessageDialogService
+IClipboardService
+IUIDispatcher
+```
+
+## Stage 5 — Editor migration
+
+Once the service layer stabilizes:
+
+- move editor interaction logic into shared components
+- gradually migrate editor UI elements
+
+The main editor window should be the last screen migrated.
+
+## Tracking progress
+
+Recommended issue labels:
+
+- `avalonia-migration`
+- `ui-refactor`
+- `viewmodel-extraction`
+
+Example milestone:
+
+```
+Avalonia Migration Phase 1
+```
+
+Tracks extraction of shared logic and view models.

--- a/docs/ui-test-harness.md
+++ b/docs/ui-test-harness.md
@@ -13,8 +13,8 @@ Example:
 ```
 driver.ClickButton("btnLoadSong")
 driver.SetText("txtSongBPM", "120")
-driver.OpenMenu("File")
-driver.SelectMenuItem("Import Map")
+driver.SendKeyboardShortcut("Alt+F")
+driver.ClickButton("miImportMap")
 ```
 
 The same tests must run against:

--- a/docs/ui-test-harness.md
+++ b/docs/ui-test-harness.md
@@ -1,6 +1,6 @@
-# Platform‑Agnostic UI Test Harness
+# Platform-Agnostic UI Test Harness
 
-To safely migrate the Edda UI from WPF to Avalonia, a **platform‑agnostic UI test harness** must validate that both implementations behave identically.
+To safely migrate the Edda UI from WPF to Avalonia, a **platform-agnostic UI test harness** must validate that both implementations behave identically.
 
 The harness acts as the specification of UI behavior.
 

--- a/docs/ui-test-harness.md
+++ b/docs/ui-test-harness.md
@@ -1,0 +1,132 @@
+# Platform‑Agnostic UI Test Harness
+
+To safely migrate the Edda UI from WPF to Avalonia, a **platform‑agnostic UI test harness** must validate that both implementations behave identically.
+
+The harness acts as the specification of UI behavior.
+
+## Core idea
+
+Tests interact with the UI through a **UI driver interface** rather than directly referencing framework controls.
+
+Example:
+
+```
+driver.ClickButton("btnLoadSong")
+driver.SetText("txtSongBPM", "120")
+driver.OpenMenu("File")
+driver.SelectMenuItem("Import Map")
+```
+
+The same tests must run against:
+
+- WPF UI implementation
+- Avalonia UI implementation
+
+## UI Driver contract
+
+Suggested interface:
+
+```
+public interface IUIDriver
+{
+    void ClickButton(string id);
+
+    void SetText(string id, string value);
+
+    string GetText(string id);
+
+    bool IsVisible(string id);
+
+    bool IsEnabled(string id);
+
+    void SelectDropdown(string id, string value);
+
+    void ToggleCheckbox(string id, bool value);
+
+    void Drag(string sourceId, string targetId);
+
+    void SendKeyboardShortcut(string shortcut);
+
+    void WaitForIdle();
+}
+```
+
+Each platform implements an adapter:
+
+- `WpfUIDriver`
+- `AvaloniaUIDriver`
+
+## Test harness structure
+
+Recommended layout:
+
+```
+tests/
+
+Edda.UI.Harness/
+    UIDriver.cs
+    UIScenario.cs
+    ScreenDefinitions/
+
+Edda.Wpf.UI.Tests/
+    WpfUIDriver.cs
+
+Edda.Avalonia.UI.Tests/
+    AvaloniaUIDriver.cs
+```
+
+## Scenario-based tests
+
+Tests should describe user scenarios rather than individual control interactions.
+
+Example scenario:
+
+```
+LoadSongScenario
+
+1 open file dialog
+2 select song
+3 waveform appears
+4 timeline initialized
+5 playback enabled
+```
+
+These scenarios become the acceptance criteria for the migration.
+
+## Coverage expectations
+
+The harness must eventually cover:
+
+- editor startup
+- song loading
+- waveform generation
+- map editing interactions
+- timeline navigation
+- drum playback
+- settings editing
+- file import/export
+- autosave
+- keyboard shortcuts
+
+## Control identification
+
+All UI elements used by the harness must have stable identifiers.
+
+Example:
+
+```
+<Button x:Name="btnLoadSong" />
+<TextBox x:Name="txtSongBPM" />
+```
+
+Avalonia UI must preserve the same identifiers.
+
+## Success criteria
+
+Migration of a screen is considered complete when:
+
+1. All harness tests for that screen pass.
+2. The Avalonia driver behaves identically to the WPF driver.
+3. No behavior regressions are detected.
+
+This harness ensures that migration is validated against **behavior**, not just appearance.

--- a/docs/wpf-split-and-analysis-plan.md
+++ b/docs/wpf-split-and-analysis-plan.md
@@ -1,0 +1,96 @@
+# WPF Split and Analysis Plan
+
+Before starting the WPF → Avalonia migration, the current WPF user interface should be isolated into its own explicit project boundary and analyzed as the baseline implementation.
+
+## Why this step is required
+
+A migration without a stable baseline makes it too easy for agents to:
+
+- regress behavior silently
+- miss edge-case interactions
+- change UI semantics while preserving only superficial layout
+- port screens without proving behavioral equivalence
+
+The WPF UI must therefore become the reference implementation against which future Avalonia behavior is validated.
+
+## Pre-migration rule
+
+No production screen should be migrated until all of the following are true:
+
+1. The legacy WPF UI is isolated behind a dedicated project boundary.
+2. The screen and its behaviors have been inventoried.
+3. The expected behavior is represented in a platform-agnostic UI test harness.
+4. The harness can drive both the WPF and future Avalonia implementations through the same driver contract.
+
+## Recommended project split
+
+Target structure:
+
+- `src/Edda.Core/`
+  - domain models
+  - editor logic
+  - map conversion logic
+  - framework-agnostic services
+- `src/Edda.App/`
+  - application services
+  - commands
+  - framework-agnostic view models
+  - UI contracts
+- `src/Edda.Wpf/`
+  - current WPF windows
+  - WPF resources
+  - WPF-specific adapters
+- `src/Edda.Avalonia/`
+  - Avalonia views
+  - Avalonia resources
+  - Avalonia-specific adapters
+- `tests/Edda.UI.Harness/`
+  - platform-agnostic UI expectations
+  - driver contract
+  - shared test scenarios
+- `tests/Edda.Wpf.UI.Tests/`
+  - WPF harness host and adapter
+- `tests/Edda.Avalonia.UI.Tests/`
+  - Avalonia harness host and adapter
+
+## Required analysis pass
+
+Before any screen is ported, perform an analysis pass over the WPF UI and record:
+
+- all windows and dialogs
+- all named controls and their roles
+- startup flows
+- keyboard shortcuts
+- mouse interactions
+- drag and drop behaviors
+- playback-related interactions
+- validation behavior
+- visibility and enabled/disabled rules
+- settings persistence behavior
+- error and confirmation dialogs
+- file import/export flows
+
+## Analysis output
+
+The analysis pass should produce a living inventory for each screen with:
+
+- screen purpose
+- required controls
+- expected initial state
+- supported user actions
+- observable outcomes
+- dependencies on services or background work
+- known timing-sensitive behavior
+
+## Migration gate
+
+The first Avalonia PR should not be a visual port.
+
+The first implementation PR should instead:
+
+1. carve out the WPF project boundary
+2. introduce the shared UI driver contract
+3. add the first version of the platform-agnostic UI harness
+4. capture baseline expectations from the WPF application
+
+Only after this gate is complete should screen-by-screen migration begin.


### PR DESCRIPTION
Adds documentation and a structured scaffold for migrating Edda from WPF to Avalonia.

## Included

- `docs/avalonia-migration.md` – architectural guidance for migrating UI
- `docs/avalonia-workplan.md` – step-by-step migration workplan

## Purpose

This scaffold provides:

- a phased migration strategy
- recommended project structure
- guidance for extracting shared logic
- a roadmap for introducing Avalonia without breaking the existing WPF application

No functional code changes were made.

This PR only introduces migration guidance to help future contributors and Codex-assisted refactors.