### PR TITLE
Bootstrap platform-agnostic UI test harness

### DIFF
--- a/RagnarockEditor.csproj
+++ b/RagnarockEditor.csproj
@@ -20,6 +20,9 @@
     <Optimize>false</Optimize>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Remove="tests\**" />
+  </ItemGroup>
+  <ItemGroup>
     <None Remove="Resources\bassdrum1.wav" />
     <None Remove="Resources\bassdrum2.wav" />
     <None Remove="Resources\bassdrum3.wav" />

--- a/RagnarockEditor.sln
+++ b/RagnarockEditor.sln
@@ -5,6 +5,12 @@ VisualStudioVersion = 16.0.31229.75
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RagnarockEditor", "RagnarockEditor.csproj", "{E0C9E6ED-0515-4547-8FDC-B54512C8A549}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Edda.UI.Harness", "tests\Edda.UI.Harness\Edda.UI.Harness.csproj", "{5B1737D6-5679-4E21-AB31-BB7C8E9C05C9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Edda.Wpf.UI.Tests", "tests\Edda.Wpf.UI.Tests\Edda.Wpf.UI.Tests.csproj", "{39CB1027-4411-4F7A-830C-EFFC810A613A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Edda.Avalonia.UI.Tests", "tests\Edda.Avalonia.UI.Tests\Edda.Avalonia.UI.Tests.csproj", "{5A8D9A94-9226-4ABF-A5F6-2651D5A26AAC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +21,18 @@ Global
 		{E0C9E6ED-0515-4547-8FDC-B54512C8A549}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E0C9E6ED-0515-4547-8FDC-B54512C8A549}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E0C9E6ED-0515-4547-8FDC-B54512C8A549}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B1737D6-5679-4E21-AB31-BB7C8E9C05C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B1737D6-5679-4E21-AB31-BB7C8E9C05C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B1737D6-5679-4E21-AB31-BB7C8E9C05C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B1737D6-5679-4E21-AB31-BB7C8E9C05C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39CB1027-4411-4F7A-830C-EFFC810A613A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39CB1027-4411-4F7A-830C-EFFC810A613A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39CB1027-4411-4F7A-830C-EFFC810A613A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39CB1027-4411-4F7A-830C-EFFC810A613A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A8D9A94-9226-4ABF-A5F6-2651D5A26AAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A8D9A94-9226-4ABF-A5F6-2651D5A26AAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A8D9A94-9226-4ABF-A5F6-2651D5A26AAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A8D9A94-9226-4ABF-A5F6-2651D5A26AAC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/Edda.Avalonia.UI.Tests/AvaloniaUIDriver.cs
+++ b/tests/Edda.Avalonia.UI.Tests/AvaloniaUIDriver.cs
@@ -1,44 +1,43 @@
 using Edda.UI.Harness;
 
-namespace Edda.Avalonia.UI.Tests;
+namespace Edda.Avalonia.UI.Tests {
+    public class AvaloniaUIDriver : IUIDriver {
+        public void Launch() => throw new NotImplementedException("AvaloniaUIDriver.Launch is not implemented yet.");
 
-public class AvaloniaUIDriver : IUIDriver
-{
-    public void Launch() { }
+        public void Shutdown() => throw new NotImplementedException("AvaloniaUIDriver.Shutdown is not implemented yet.");
 
-    public void Shutdown() { }
+        public void WaitForIdle(TimeSpan? timeout = null) => throw new NotImplementedException("AvaloniaUIDriver.WaitForIdle is not implemented yet.");
 
-    public void WaitForIdle() { }
+        public void ClickButton(string id) => throw new NotImplementedException("AvaloniaUIDriver.ClickButton is not implemented yet.");
 
-    public void ClickButton(string id) { }
+        public void SetText(string id, string value) => throw new NotImplementedException("AvaloniaUIDriver.SetText is not implemented yet.");
 
-    public void SetText(string id, string value) { }
+        public string GetText(string id) => throw new NotImplementedException("AvaloniaUIDriver.GetText is not implemented yet.");
 
-    public string GetText(string id) => string.Empty;
+        public bool IsVisible(string id) => throw new NotImplementedException("AvaloniaUIDriver.IsVisible is not implemented yet.");
 
-    public bool IsVisible(string id) => false;
+        public bool IsEnabled(string id) => throw new NotImplementedException("AvaloniaUIDriver.IsEnabled is not implemented yet.");
 
-    public bool IsEnabled(string id) => false;
+        public bool IsChecked(string id) => throw new NotImplementedException("AvaloniaUIDriver.IsChecked is not implemented yet.");
 
-    public bool IsChecked(string id) => false;
+        public void ToggleCheckbox(string id, bool value) => throw new NotImplementedException("AvaloniaUIDriver.ToggleCheckbox is not implemented yet.");
 
-    public void ToggleCheckbox(string id, bool value) { }
+        public string GetSelectedValue(string id) => throw new NotImplementedException("AvaloniaUIDriver.GetSelectedValue is not implemented yet.");
 
-    public string GetSelectedValue(string id) => string.Empty;
+        public void SelectDropdown(string id, string value) => throw new NotImplementedException("AvaloniaUIDriver.SelectDropdown is not implemented yet.");
 
-    public void SelectDropdown(string id, string value) { }
+        public void OpenMenu(string id) => throw new NotImplementedException("AvaloniaUIDriver.OpenMenu is not implemented yet.");
 
-    public void OpenMenu(string id) { }
+        public void SelectMenuItem(string path) => throw new NotImplementedException("AvaloniaUIDriver.SelectMenuItem is not implemented yet.");
 
-    public void SelectMenuItem(string path) { }
+        public void SendKeyboardShortcut(string shortcut) => throw new NotImplementedException("AvaloniaUIDriver.SendKeyboardShortcut is not implemented yet.");
 
-    public void SendKeyboardShortcut(string shortcut) { }
+        public void Drag(string sourceId, string targetId) => throw new NotImplementedException("AvaloniaUIDriver.Drag is not implemented yet.");
 
-    public void Drag(string sourceId, string targetId) { }
+        public void InvokeCommand(string commandId) => throw new NotImplementedException("AvaloniaUIDriver.InvokeCommand is not implemented yet.");
 
-    public void InvokeCommand(string commandId) { }
+        public void SetTestFileSelection(string path) => throw new NotImplementedException("AvaloniaUIDriver.SetTestFileSelection is not implemented yet.");
 
-    public void SetTestFileSelection(string path) { }
-
-    public void AssertNotificationContains(string text) { }
+        public void AssertNotificationContains(string text) => throw new NotImplementedException("AvaloniaUIDriver.AssertNotificationContains is not implemented yet.");
+    }
 }

--- a/tests/Edda.Avalonia.UI.Tests/AvaloniaUIDriver.cs
+++ b/tests/Edda.Avalonia.UI.Tests/AvaloniaUIDriver.cs
@@ -1,0 +1,44 @@
+using Edda.UI.Harness;
+
+namespace Edda.Avalonia.UI.Tests;
+
+public class AvaloniaUIDriver : IUIDriver
+{
+    public void Launch() { }
+
+    public void Shutdown() { }
+
+    public void WaitForIdle() { }
+
+    public void ClickButton(string id) { }
+
+    public void SetText(string id, string value) { }
+
+    public string GetText(string id) => string.Empty;
+
+    public bool IsVisible(string id) => false;
+
+    public bool IsEnabled(string id) => false;
+
+    public bool IsChecked(string id) => false;
+
+    public void ToggleCheckbox(string id, bool value) { }
+
+    public string GetSelectedValue(string id) => string.Empty;
+
+    public void SelectDropdown(string id, string value) { }
+
+    public void OpenMenu(string id) { }
+
+    public void SelectMenuItem(string path) { }
+
+    public void SendKeyboardShortcut(string shortcut) { }
+
+    public void Drag(string sourceId, string targetId) { }
+
+    public void InvokeCommand(string commandId) { }
+
+    public void SetTestFileSelection(string path) { }
+
+    public void AssertNotificationContains(string text) { }
+}

--- a/tests/Edda.Avalonia.UI.Tests/Edda.Avalonia.UI.Tests.csproj
+++ b/tests/Edda.Avalonia.UI.Tests/Edda.Avalonia.UI.Tests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Edda.UI.Harness\Edda.UI.Harness.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Edda.UI.Harness/Edda.UI.Harness.csproj
+++ b/tests/Edda.UI.Harness/Edda.UI.Harness.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/Edda.UI.Harness/IUIDriver.cs
+++ b/tests/Edda.UI.Harness/IUIDriver.cs
@@ -1,0 +1,42 @@
+namespace Edda.UI.Harness;
+
+public interface IUIDriver
+{
+    void Launch();
+
+    void Shutdown();
+
+    void WaitForIdle();
+
+    void ClickButton(string id);
+
+    void SetText(string id, string value);
+
+    string GetText(string id);
+
+    bool IsVisible(string id);
+
+    bool IsEnabled(string id);
+
+    bool IsChecked(string id);
+
+    void ToggleCheckbox(string id, bool value);
+
+    string GetSelectedValue(string id);
+
+    void SelectDropdown(string id, string value);
+
+    void OpenMenu(string id);
+
+    void SelectMenuItem(string path);
+
+    void SendKeyboardShortcut(string shortcut);
+
+    void Drag(string sourceId, string targetId);
+
+    void InvokeCommand(string commandId);
+
+    void SetTestFileSelection(string path);
+
+    void AssertNotificationContains(string text);
+}

--- a/tests/Edda.UI.Harness/IUIDriver.cs
+++ b/tests/Edda.UI.Harness/IUIDriver.cs
@@ -1,42 +1,41 @@
-namespace Edda.UI.Harness;
+namespace Edda.UI.Harness {
+    public interface IUIDriver {
+        void Launch();
 
-public interface IUIDriver
-{
-    void Launch();
+        void Shutdown();
 
-    void Shutdown();
+        void WaitForIdle(TimeSpan? timeout = null);
 
-    void WaitForIdle();
+        void ClickButton(string id);
 
-    void ClickButton(string id);
+        void SetText(string id, string value);
 
-    void SetText(string id, string value);
+        string GetText(string id);
 
-    string GetText(string id);
+        bool IsVisible(string id);
 
-    bool IsVisible(string id);
+        bool IsEnabled(string id);
 
-    bool IsEnabled(string id);
+        bool IsChecked(string id);
 
-    bool IsChecked(string id);
+        void ToggleCheckbox(string id, bool value);
 
-    void ToggleCheckbox(string id, bool value);
+        string GetSelectedValue(string id);
 
-    string GetSelectedValue(string id);
+        void SelectDropdown(string id, string value);
 
-    void SelectDropdown(string id, string value);
+        void OpenMenu(string id);
 
-    void OpenMenu(string id);
+        void SelectMenuItem(string path);
 
-    void SelectMenuItem(string path);
+        void SendKeyboardShortcut(string shortcut);
 
-    void SendKeyboardShortcut(string shortcut);
+        void Drag(string sourceId, string targetId);
 
-    void Drag(string sourceId, string targetId);
+        void InvokeCommand(string commandId);
 
-    void InvokeCommand(string commandId);
+        void SetTestFileSelection(string path);
 
-    void SetTestFileSelection(string path);
-
-    void AssertNotificationContains(string text);
+        void AssertNotificationContains(string text);
+    }
 }

--- a/tests/Edda.UI.Harness/Scenarios/StartupScenario.cs
+++ b/tests/Edda.UI.Harness/Scenarios/StartupScenario.cs
@@ -1,23 +1,23 @@
-namespace Edda.UI.Harness.Scenarios;
+namespace Edda.UI.Harness.Scenarios {
+    public class StartupScenario : UIScenario {
+        public override string Name => "Startup";
 
-public class StartupScenario : UIScenario
-{
-    public override string Name => "Startup";
+        public override void Run(IUIDriver driver) {
+            try {
+                driver.Launch();
 
-    public override void Run(IUIDriver driver)
-    {
-        driver.Launch();
+                driver.WaitForIdle();
 
-        driver.WaitForIdle();
+                if (!driver.IsVisible("MainWindow")) {
+                    throw new Exception("Main window did not appear after startup.");
+                }
 
-        if (!driver.IsVisible("MainWindow"))
-        {
-            throw new Exception("Main window did not appear after startup.");
-        }
-
-        if (!driver.IsEnabled("btnLoadSong"))
-        {
-            throw new Exception("Load Song button should be enabled on startup.");
+                if (!driver.IsEnabled("btnLoadSong")) {
+                    throw new Exception("Load Song button should be enabled on startup.");
+                }
+            } finally {
+                driver.Shutdown();
+            }
         }
     }
 }

--- a/tests/Edda.UI.Harness/Scenarios/StartupScenario.cs
+++ b/tests/Edda.UI.Harness/Scenarios/StartupScenario.cs
@@ -1,0 +1,23 @@
+namespace Edda.UI.Harness.Scenarios;
+
+public class StartupScenario : UIScenario
+{
+    public override string Name => "Startup";
+
+    public override void Run(IUIDriver driver)
+    {
+        driver.Launch();
+
+        driver.WaitForIdle();
+
+        if (!driver.IsVisible("MainWindow"))
+        {
+            throw new Exception("Main window did not appear after startup.");
+        }
+
+        if (!driver.IsEnabled("btnLoadSong"))
+        {
+            throw new Exception("Load Song button should be enabled on startup.");
+        }
+    }
+}

--- a/tests/Edda.UI.Harness/UIScenario.cs
+++ b/tests/Edda.UI.Harness/UIScenario.cs
@@ -1,0 +1,8 @@
+namespace Edda.UI.Harness;
+
+public abstract class UIScenario
+{
+    public abstract string Name { get; }
+
+    public abstract void Run(IUIDriver driver);
+}

--- a/tests/Edda.UI.Harness/UIScenario.cs
+++ b/tests/Edda.UI.Harness/UIScenario.cs
@@ -1,8 +1,7 @@
-namespace Edda.UI.Harness;
+namespace Edda.UI.Harness {
+    public abstract class UIScenario {
+        public abstract string Name { get; }
 
-public abstract class UIScenario
-{
-    public abstract string Name { get; }
-
-    public abstract void Run(IUIDriver driver);
+        public abstract void Run(IUIDriver driver);
+    }
 }

--- a/tests/Edda.Wpf.UI.Tests/Edda.Wpf.UI.Tests.csproj
+++ b/tests/Edda.Wpf.UI.Tests/Edda.Wpf.UI.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Edda.UI.Harness\Edda.UI.Harness.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Edda.Wpf.UI.Tests/WpfUIDriver.cs
+++ b/tests/Edda.Wpf.UI.Tests/WpfUIDriver.cs
@@ -1,44 +1,43 @@
 using Edda.UI.Harness;
 
-namespace Edda.Wpf.UI.Tests;
+namespace Edda.Wpf.UI.Tests {
+    public class WpfUIDriver : IUIDriver {
+        public void Launch() => throw new NotImplementedException("WpfUIDriver.Launch is not implemented yet.");
 
-public class WpfUIDriver : IUIDriver
-{
-    public void Launch() { }
+        public void Shutdown() => throw new NotImplementedException("WpfUIDriver.Shutdown is not implemented yet.");
 
-    public void Shutdown() { }
+        public void WaitForIdle(TimeSpan? timeout = null) => throw new NotImplementedException("WpfUIDriver.WaitForIdle is not implemented yet.");
 
-    public void WaitForIdle() { }
+        public void ClickButton(string id) => throw new NotImplementedException("WpfUIDriver.ClickButton is not implemented yet.");
 
-    public void ClickButton(string id) { }
+        public void SetText(string id, string value) => throw new NotImplementedException("WpfUIDriver.SetText is not implemented yet.");
 
-    public void SetText(string id, string value) { }
+        public string GetText(string id) => throw new NotImplementedException("WpfUIDriver.GetText is not implemented yet.");
 
-    public string GetText(string id) => string.Empty;
+        public bool IsVisible(string id) => throw new NotImplementedException("WpfUIDriver.IsVisible is not implemented yet.");
 
-    public bool IsVisible(string id) => false;
+        public bool IsEnabled(string id) => throw new NotImplementedException("WpfUIDriver.IsEnabled is not implemented yet.");
 
-    public bool IsEnabled(string id) => false;
+        public bool IsChecked(string id) => throw new NotImplementedException("WpfUIDriver.IsChecked is not implemented yet.");
 
-    public bool IsChecked(string id) => false;
+        public void ToggleCheckbox(string id, bool value) => throw new NotImplementedException("WpfUIDriver.ToggleCheckbox is not implemented yet.");
 
-    public void ToggleCheckbox(string id, bool value) { }
+        public string GetSelectedValue(string id) => throw new NotImplementedException("WpfUIDriver.GetSelectedValue is not implemented yet.");
 
-    public string GetSelectedValue(string id) => string.Empty;
+        public void SelectDropdown(string id, string value) => throw new NotImplementedException("WpfUIDriver.SelectDropdown is not implemented yet.");
 
-    public void SelectDropdown(string id, string value) { }
+        public void OpenMenu(string id) => throw new NotImplementedException("WpfUIDriver.OpenMenu is not implemented yet.");
 
-    public void OpenMenu(string id) { }
+        public void SelectMenuItem(string path) => throw new NotImplementedException("WpfUIDriver.SelectMenuItem is not implemented yet.");
 
-    public void SelectMenuItem(string path) { }
+        public void SendKeyboardShortcut(string shortcut) => throw new NotImplementedException("WpfUIDriver.SendKeyboardShortcut is not implemented yet.");
 
-    public void SendKeyboardShortcut(string shortcut) { }
+        public void Drag(string sourceId, string targetId) => throw new NotImplementedException("WpfUIDriver.Drag is not implemented yet.");
 
-    public void Drag(string sourceId, string targetId) { }
+        public void InvokeCommand(string commandId) => throw new NotImplementedException("WpfUIDriver.InvokeCommand is not implemented yet.");
 
-    public void InvokeCommand(string commandId) { }
+        public void SetTestFileSelection(string path) => throw new NotImplementedException("WpfUIDriver.SetTestFileSelection is not implemented yet.");
 
-    public void SetTestFileSelection(string path) { }
-
-    public void AssertNotificationContains(string text) { }
+        public void AssertNotificationContains(string text) => throw new NotImplementedException("WpfUIDriver.AssertNotificationContains is not implemented yet.");
+    }
 }

--- a/tests/Edda.Wpf.UI.Tests/WpfUIDriver.cs
+++ b/tests/Edda.Wpf.UI.Tests/WpfUIDriver.cs
@@ -1,0 +1,44 @@
+using Edda.UI.Harness;
+
+namespace Edda.Wpf.UI.Tests;
+
+public class WpfUIDriver : IUIDriver
+{
+    public void Launch() { }
+
+    public void Shutdown() { }
+
+    public void WaitForIdle() { }
+
+    public void ClickButton(string id) { }
+
+    public void SetText(string id, string value) { }
+
+    public string GetText(string id) => string.Empty;
+
+    public bool IsVisible(string id) => false;
+
+    public bool IsEnabled(string id) => false;
+
+    public bool IsChecked(string id) => false;
+
+    public void ToggleCheckbox(string id, bool value) { }
+
+    public string GetSelectedValue(string id) => string.Empty;
+
+    public void SelectDropdown(string id, string value) { }
+
+    public void OpenMenu(string id) { }
+
+    public void SelectMenuItem(string path) { }
+
+    public void SendKeyboardShortcut(string shortcut) { }
+
+    public void Drag(string sourceId, string targetId) { }
+
+    public void InvokeCommand(string commandId) { }
+
+    public void SetTestFileSelection(string path) { }
+
+    public void AssertNotificationContains(string text) { }
+}


### PR DESCRIPTION
Introduces the first implementation of the platform-agnostic UI harness required for the WPF → Avalonia migration.

## Included

New harness projects:

- `tests/Edda.UI.Harness` – shared driver contract and UI scenarios
- `tests/Edda.Wpf.UI.Tests` – WPF driver placeholder
- `tests/Edda.Avalonia.UI.Tests` – Avalonia driver placeholder

Key components:

- `IUIDriver` contract defining how tests interact with UI elements
- `UIScenario` abstraction for behavior-driven UI scenarios
- `StartupScenario` example verifying baseline application startup behavior

## Purpose

This harness allows the same UI scenarios to be executed against both:

- the legacy WPF UI
- the future Avalonia UI

By enforcing identical behavior across implementations, this harness becomes the specification of UI functionality during migration.

## Next steps

Follow-up PRs will:

1. Implement the WPF automation driver
2. Add scenario coverage for key editor workflows
3. Introduce a scenario runner
4. Begin extracting WPF UI into `Edda.Wpf` project

No production code was modified in this PR.